### PR TITLE
[feat] 리뷰 부분 아이템 컴포넌트에 대한 ui 리팩토링 및 일부 수정

### DIFF
--- a/.idea/appInsightsSettings.xml
+++ b/.idea/appInsightsSettings.xml
@@ -4,6 +4,20 @@
     <option name="selectedTabId" value="Android Vitals" />
     <option name="tabSettings">
       <map>
+        <entry key="Android Vitals">
+          <value>
+            <InsightsFilterSettings>
+              <option name="connection">
+                <ConnectionSetting>
+                  <option name="appId" value="inu.appcenter.intip_android" />
+                </ConnectionSetting>
+              </option>
+              <option name="signal" value="SIGNAL_UNSPECIFIED" />
+              <option name="timeIntervalDays" value="SEVEN_DAYS" />
+              <option name="visibilityType" value="ALL" />
+            </InsightsFilterSettings>
+          </value>
+        </entry>
         <entry key="Firebase Crashlytics">
           <value>
             <InsightsFilterSettings>

--- a/app/src/main/java/inu/appcenter/bjj_android/ui/review/component/ReviewItemCard.kt
+++ b/app/src/main/java/inu/appcenter/bjj_android/ui/review/component/ReviewItemCard.kt
@@ -1,0 +1,98 @@
+package inu.appcenter.bjj_android.ui.review.component
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import inu.appcenter.bjj_android.LocalTypography
+import inu.appcenter.bjj_android.R
+import inu.appcenter.bjj_android.model.review.MyReviewDetailRes
+import inu.appcenter.bjj_android.ui.theme.Gray_999999
+import inu.appcenter.bjj_android.ui.theme.Gray_B9B9B9
+import inu.appcenter.bjj_android.ui.theme.Orange_FF7800
+
+/**
+ * 리뷰 아이템 카드 컴포넌트
+ *
+ * @param reviewItem 리뷰 항목 데이터
+ * @param onClick 아이템 클릭 시 실행할 콜백
+ */
+@Composable
+fun ReviewItemCard(
+    reviewItem: MyReviewDetailRes,
+    onClick: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(63.dp)
+            .border(0.5.dp, Gray_B9B9B9, shape = RoundedCornerShape(3.dp))
+            .clickable { onClick() }
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(horizontal = 9.dp)
+                .fillMaxWidth()
+        ) {
+            Spacer(Modifier.height(12.dp))
+            Text(
+                text = reviewItem.mainMenuName,
+                style = LocalTypography.current.semibold15.copy(
+                    letterSpacing = 0.13.sp,
+                    lineHeight = 18.sp,
+                ),
+                color = Color.Black
+            )
+            Spacer(Modifier.height(5.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = reviewItem.createdDate.formatter(),
+                    style = LocalTypography.current.regular13.copy(
+                        letterSpacing = 0.13.sp,
+                        lineHeight = 17.sp,
+                    ),
+                    color = Gray_999999
+                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        painter = painterResource(R.drawable.star),
+                        contentDescription = stringResource(R.string.full_star_description),
+                        tint = Orange_FF7800
+                    )
+                    Spacer(Modifier.width(4.dp))
+                    Text(
+                        text = reviewItem.rating.toString(),
+                        style = LocalTypography.current.semibold15.copy(
+                            letterSpacing = 0.13.sp,
+                            lineHeight = 18.sp,
+                        ),
+                        color = Color.Black
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/inu/appcenter/bjj_android/ui/review/component/ReviewItemCard.kt
+++ b/app/src/main/java/inu/appcenter/bjj_android/ui/review/component/ReviewItemCard.kt
@@ -89,7 +89,8 @@ fun ReviewItemCard(
                             letterSpacing = 0.13.sp,
                             lineHeight = 18.sp,
                         ),
-                        color = Color.Black
+                        color = Color.Black,
+                        modifier = Modifier.width(13.dp) // 고정된 너비 설정해서 숫자에 따른 별 위치가 안 바뀌게 보이도록함 
                     )
                 }
             }

--- a/app/src/main/java/inu/appcenter/bjj_android/ui/review/page/MoreRead.kt
+++ b/app/src/main/java/inu/appcenter/bjj_android/ui/review/page/MoreRead.kt
@@ -2,22 +2,16 @@ package inu.appcenter.bjj_android.ui.review.page
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -43,9 +37,7 @@ import inu.appcenter.bjj_android.R
 import inu.appcenter.bjj_android.model.review.MyReviewDetailRes
 import inu.appcenter.bjj_android.ui.component.noRippleClickable
 import inu.appcenter.bjj_android.ui.review.ReviewViewModel
-import inu.appcenter.bjj_android.ui.theme.Gray_999999
-import inu.appcenter.bjj_android.ui.theme.Gray_B9B9B9
-import inu.appcenter.bjj_android.ui.theme.Orange_FF7800
+import inu.appcenter.bjj_android.ui.review.component.ReviewItemCard
 import inu.appcenter.bjj_android.ui.theme.paddings
 
 private val BOTTOM_SPACER_HEIGHT = 28.dp
@@ -54,7 +46,7 @@ private val BOTTOM_SPACER_HEIGHT = 28.dp
 @Composable
 fun MoreReadScreen(
     onNavigateBack: () -> Unit,
-    onNavigateToReviewDetail: (MyReviewDetailRes) -> Unit,  // 타입 명시
+    onNavigateToReviewDetail: (MyReviewDetailRes) -> Unit,
     reviewViewModel: ReviewViewModel
 ) {
     val reviewUiState by reviewViewModel.uiState.collectAsState()
@@ -108,63 +100,12 @@ fun MoreReadScreen(
             ) {
                 reviewUiState.reviewsChoiceByRestaurant?.myReviewDetailList?.let {
                     items(it) { item ->
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(63.dp)
-                                .border(0.5.dp, Gray_B9B9B9, shape = RoundedCornerShape(3.dp))
-                                .clickable {
-                                    onNavigateToReviewDetail(item)
-                                }
-                        ) {
-                            Column(
-                                modifier = Modifier
-                                    .padding(horizontal = 9.dp)
-                                    .fillMaxWidth()
-                            ) {
-                                Spacer(Modifier.height(12.dp))
-                                Text(
-                                    text = item.mainMenuName,
-                                    style = LocalTypography.current.semibold15.copy(
-                                        letterSpacing = 0.13.sp,
-                                        lineHeight = 18.sp,
-                                    ),
-                                    color = Color.Black
-                                )
-                                Spacer(Modifier.height(5.dp))
-
-                                Row(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    horizontalArrangement = Arrangement.SpaceBetween,
-                                    verticalAlignment = Alignment.CenterVertically
-                                ) {
-                                    Text(
-                                        text = item.createdDate.format(),
-                                        style = LocalTypography.current.regular13.copy(
-                                            letterSpacing = 0.13.sp,
-                                            lineHeight = 17.sp,
-                                        ),
-                                        color = Gray_999999
-                                    )
-                                    Row(verticalAlignment = Alignment.CenterVertically) {
-                                        Icon(
-                                            painter = painterResource(R.drawable.star),
-                                            contentDescription = stringResource(R.string.full_star_description),
-                                            tint = Orange_FF7800
-                                        )
-                                        Spacer(Modifier.width(4.dp))
-                                        Text(
-                                            text = item.rating.toString(),
-                                            style = LocalTypography.current.semibold15.copy(
-                                                letterSpacing = 0.13.sp,
-                                                lineHeight = 18.sp,
-                                            ),
-                                            color = Color.Black
-                                        )
-                                    }
-                                }
+                        ReviewItemCard(
+                            reviewItem = item,
+                            onClick = {
+                                onNavigateToReviewDetail(item)
                             }
-                        }
+                        )
                         Spacer(Modifier.height(10.dp))
                     }
 

--- a/app/src/main/java/inu/appcenter/bjj_android/ui/review/reviewPagePart/ReviewFrame.kt
+++ b/app/src/main/java/inu/appcenter/bjj_android/ui/review/reviewPagePart/ReviewFrame.kt
@@ -1,18 +1,13 @@
 package inu.appcenter.bjj_android.ui.review.reviewPagePart
 
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -20,8 +15,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -31,10 +24,8 @@ import inu.appcenter.bjj_android.R
 import inu.appcenter.bjj_android.ui.component.HorizontalDivider
 import inu.appcenter.bjj_android.ui.navigate.AllDestination
 import inu.appcenter.bjj_android.ui.review.ReviewViewModel
-import inu.appcenter.bjj_android.ui.review.component.formatter
+import inu.appcenter.bjj_android.ui.review.component.ReviewItemCard
 import inu.appcenter.bjj_android.ui.theme.Gray_999999
-import inu.appcenter.bjj_android.ui.theme.Gray_B9B9B9
-import inu.appcenter.bjj_android.ui.theme.Orange_FF7800
 import inu.appcenter.bjj_android.ui.theme.paddings
 
 @Composable
@@ -86,64 +77,13 @@ fun ReviewFrameScreen(
 
         Column {
             reviewUiState.reviews?.myReviewDetailList?.get(selectRestaurantName)?.take(3)?.forEach { item ->
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(63.dp)
-                        .border(0.5.dp, Gray_B9B9B9, shape = RoundedCornerShape(3.dp))
-                        .clickable {
-                            reviewViewModel.setSelectedReviewDetail(item)
-                            navController.navigate(AllDestination.ReviewDetail.route)
-                        }
-                ) {
-                    Column(
-                        modifier = Modifier
-                            .padding(horizontal = 9.dp)
-                            .fillMaxWidth()
-                    ) {
-                        Spacer(Modifier.height(12.dp))
-                        Text(
-                            text = item.mainMenuName,//임시
-                            style = LocalTypography.current.semibold15.copy(
-                                letterSpacing = 0.13.sp,
-                                lineHeight = 18.sp,
-                            ),
-                            color = Color.Black
-                        )
-                        Spacer(Modifier.height(5.dp))
-
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Text(
-                                text = item.createdDate.formatter(),
-                                style = LocalTypography.current.regular13.copy(
-                                    letterSpacing = 0.13.sp,
-                                    lineHeight = 17.sp,
-                                ),
-                                color = Gray_999999
-                            )
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                Icon(
-                                    painter = painterResource(R.drawable.star),
-                                    contentDescription = stringResource(R.string.full_star_description),
-                                    tint = Orange_FF7800
-                                )
-                                Spacer(Modifier.width(4.dp))
-                                Text(
-                                    text = item.rating.toString(),
-                                    style = LocalTypography.current.semibold15.copy(
-                                        letterSpacing = 0.13.sp,
-                                        lineHeight = 18.sp,
-                                    ),
-                                    color = Color.Black
-                                )
-                            }
-                        }
+                ReviewItemCard(
+                    reviewItem = item,
+                    onClick = {
+                        reviewViewModel.setSelectedReviewDetail(item)
+                        navController.navigate(AllDestination.ReviewDetail.route)
                     }
-                }
+                )
                 Spacer(Modifier.height(10.dp))
             }
         }


### PR DESCRIPTION
- 리뷰 아이템 컴포넌트를 분리해서 리뷰 페이지와 더보기 페이지에서 재사용하도록 수정

- 리뷰 아이템 카드 컴포넌트에서 숫자에 따른 약간의 별 위치 변경을 막기 위해 숫자 칸에 고정 공간을 할당
